### PR TITLE
feat: add Package Manager support

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -125,3 +125,16 @@ export function unwrapStart(value: number | 'now'): number {
 	if (typeof value === 'number') return value
 	throw new Error("Cannot unwrap start that is set to 'now'")
 }
+
+export function changeExtension(fileName: string, newExt: string): string {
+	const pos = fileName.includes('.') ? fileName.lastIndexOf('.') : fileName.length
+	const fileRoot = fileName.substring(0, pos)
+	const output = `${fileRoot}.${newExt}`
+	return output
+}
+
+export function stripExtension(fileName: string): string {
+	const pos = fileName.includes('.') ? fileName.lastIndexOf('.') : fileName.length
+	const fileRoot = fileName.substring(0, pos)
+	return fileRoot
+}

--- a/src/showstyle0/part-adapters/titles.ts
+++ b/src/showstyle0/part-adapters/titles.ts
@@ -1,4 +1,10 @@
-import { BlueprintResultPart, IBlueprintPiece, PieceLifespan, TSR } from '@sofie-automation/blueprints-integration'
+import {
+	BlueprintResultPart,
+	ExpectedPackage,
+	IBlueprintPiece,
+	PieceLifespan,
+	TSR,
+} from '@sofie-automation/blueprints-integration'
 import { PartContext } from '../../common/context'
 import { literal } from '../../common/util'
 import { StudioConfig } from '../../studio0/helpers/config'
@@ -43,6 +49,29 @@ export function generateOpenerPart(context: PartContext, part: PartProps<TitlesP
 				}),
 			],
 		},
+
+		expectedPackages: [
+			literal<ExpectedPackage.ExpectedPackageMediaFile>({
+				_id: context.getHashId('assets/Sofie News Opener.mp4', true),
+				layers: [CasparCGLayers.CasparCGClipPlayer],
+				type: ExpectedPackage.PackageType.MEDIA_FILE,
+				content: {
+					filePath: 'assets/Sofie News Opener.mp4',
+				},
+				version: {},
+				contentVersionHash: '',
+				sources: [],
+				sideEffect: {
+					previewPackageSettings: {
+						path: 'previews/assets/Sofie News Opener.webm',
+					},
+					thumbnailPackageSettings: {
+						path: 'thumbnails/assets/Sofie News Opener.jpg',
+						seekTime: 1500,
+					},
+				},
+			}),
+		],
 	}
 
 	const audioBedPiece = literal<IBlueprintPiece>({
@@ -84,6 +113,27 @@ export function generateOpenerPart(context: PartContext, part: PartProps<TitlesP
 				}),
 			],
 		},
+
+		expectedPackages: [
+			literal<ExpectedPackage.ExpectedPackageMediaFile>({
+				_id: context.getHashId('assets/Sofie News Opener Audio Bed.wav', true),
+				layers: [CasparCGLayers.CasparCGClipPlayer],
+				type: ExpectedPackage.PackageType.MEDIA_FILE,
+				content: {
+					filePath: 'assets/Sofie News Opener Audio Bed.wav',
+				},
+				version: {},
+				contentVersionHash: '',
+				sources: [],
+				sideEffect: {
+					// HACK: Disable preview and thumbnail generation.
+					// Once release39 is out, we can remove the "as any" from these values, and it will no longer be a hack.
+					// https://github.com/nrkno/tv-automation-server-core/commit/5e0a9c36c628be92370c035f78c8a8f278debbfa
+					previewContainerId: null as any,
+					thumbnailContainerId: null as any,
+				},
+			}),
+		],
 	})
 
 	const pieces = [cameraPiece, audioBedPiece]

--- a/src/showstyle0/part-adapters/vo.ts
+++ b/src/showstyle0/part-adapters/vo.ts
@@ -1,6 +1,12 @@
-import { BlueprintResultPart, IBlueprintPiece, PieceLifespan, TSR } from '@sofie-automation/blueprints-integration'
+import {
+	BlueprintResultPart,
+	ExpectedPackage,
+	IBlueprintPiece,
+	PieceLifespan,
+	TSR,
+} from '@sofie-automation/blueprints-integration'
 import { PartContext } from '../../common/context'
-import { literal } from '../../common/util'
+import { changeExtension, literal, stripExtension } from '../../common/util'
 import { StudioConfig } from '../../studio0/helpers/config'
 import { CasparCGLayers } from '../../studio0/layers'
 import { PartProps, VOProps } from '../definitions'
@@ -38,11 +44,34 @@ export function generateVOPart(context: PartContext, part: PartProps<VOProps>): 
 						deviceType: TSR.DeviceType.CASPARCG,
 						type: TSR.TimelineContentTypeCasparCg.MEDIA,
 
-						file: part.payload.clipProps.fileName,
+						file: stripExtension(part.payload.clipProps.fileName),
 					},
 				}),
 			],
 		},
+
+		expectedPackages: [
+			literal<ExpectedPackage.ExpectedPackageMediaFile>({
+				_id: context.getHashId(part.payload.clipProps.fileName, true),
+				layers: [CasparCGLayers.CasparCGClipPlayer],
+				type: ExpectedPackage.PackageType.MEDIA_FILE,
+				content: {
+					filePath: part.payload.clipProps.fileName,
+				},
+				version: {},
+				contentVersionHash: '',
+				sources: [],
+				sideEffect: {
+					previewPackageSettings: {
+						path: `previews/${changeExtension(part.payload.clipProps.fileName, 'webm')}`,
+					},
+					thumbnailPackageSettings: {
+						path: `thumbnails/${changeExtension(part.payload.clipProps.fileName, 'jpg')}`,
+						seekTime: 0,
+					},
+				},
+			}),
+		],
 	}
 
 	const pieces = [cameraPiece]

--- a/src/showstyle0/part-adapters/vt.ts
+++ b/src/showstyle0/part-adapters/vt.ts
@@ -1,6 +1,12 @@
-import { BlueprintResultPart, IBlueprintPiece, PieceLifespan, TSR } from '@sofie-automation/blueprints-integration'
+import {
+	BlueprintResultPart,
+	ExpectedPackage,
+	IBlueprintPiece,
+	PieceLifespan,
+	TSR,
+} from '@sofie-automation/blueprints-integration'
 import { PartContext } from '../../common/context'
-import { literal } from '../../common/util'
+import { changeExtension, literal, stripExtension } from '../../common/util'
 import { AudioSourceType, StudioConfig } from '../../studio0/helpers/config'
 import { CasparCGLayers } from '../../studio0/layers'
 import { PartProps, VTProps } from '../definitions'
@@ -40,13 +46,35 @@ export function generateVTPart(context: PartContext, part: PartProps<VTProps>): 
 						deviceType: TSR.DeviceType.CASPARCG,
 						type: TSR.TimelineContentTypeCasparCg.MEDIA,
 
-						file: part.payload.clipProps.fileName,
+						file: stripExtension(part.payload.clipProps.fileName),
 					},
 				}),
 
 				audioTlObj,
 			],
 		},
+		expectedPackages: [
+			literal<ExpectedPackage.ExpectedPackageMediaFile>({
+				_id: context.getHashId(part.payload.clipProps.fileName, true),
+				layers: [CasparCGLayers.CasparCGClipPlayer],
+				type: ExpectedPackage.PackageType.MEDIA_FILE,
+				content: {
+					filePath: part.payload.clipProps.fileName,
+				},
+				version: {},
+				contentVersionHash: '',
+				sources: [],
+				sideEffect: {
+					previewPackageSettings: {
+						path: `previews/${changeExtension(part.payload.clipProps.fileName, 'webm')}`,
+					},
+					thumbnailPackageSettings: {
+						path: `thumbnails/${changeExtension(part.payload.clipProps.fileName, 'jpg')}`,
+						seekTime: 0,
+					},
+				},
+			}),
+		],
 	}
 
 	const pieces = [vtPiece]


### PR DESCRIPTION
This PR adds [Package Manager](https://github.com/nrkno/tv-automation-package-manager) support by adding an `expectedPackages` property to the media pieces used by `titles`, `vt`, and `vo` parts. The result is accurate media statuses in the rundown view, as well as preview and thumbnail generation.

Note: currently, the preview hoverscrubs don't work properly and always just show the first frame of the preview. This is because our `content` objects do not provide a `sourceDuration`. In the future, this may change and we may be able to get fully-functional preview hoverscrubs without needing to manually compute and provide a `sourceDuration`.