### PR TITLE
Tag adLibs

### DIFF
--- a/src/showstyle0/definitions/index.ts
+++ b/src/showstyle0/definitions/index.ts
@@ -1,8 +1,34 @@
 import { ITranslatableMessage } from '@sofie-automation/blueprints-integration'
 import { GraphicObject, SomeObject } from '../../common/definitions/objects'
 import { ClipProps } from '../helpers/clips'
+import { sanitizeName } from '../helpers/sanitize'
 import { RawSourceInfo } from '../helpers/sources'
 import { IntermediatePart, IntermediateSegment } from './intermediate'
+
+export enum AdLibTags {
+	Camera = 'camera',
+	Live = 'live',
+	Queue = 'queue',
+	DirectCut = 'direct_cut',
+}
+
+/**
+ * Creates an adLib tag for a particular camera, example:
+ * 	AdLibTagCamera('host') -> 'camera_host'
+ * @param camera Name of the camera to generate a tag for
+ */
+export function adLibTagCamera(camera: string) {
+	return `camera_${sanitizeName(camera)}`
+}
+
+/**
+ * Creates an adLib tag for a particular live, example:
+ * 	AdLibTagLive('westminster') -> 'live_westminster'
+ * @param live Name of the live to generate a tag for
+ */
+export function adLibTagLive(live: string) {
+	return `live_${sanitizeName(live)}`
+}
 
 export enum SegmentType {
 	NORMAL = 'normal',

--- a/src/showstyle0/helpers/sanitize.ts
+++ b/src/showstyle0/helpers/sanitize.ts
@@ -1,0 +1,9 @@
+/**
+ * Sanitizes the names of "things" by removing whitespace and replacing dashes with underscores.
+ *  This function does not attempt to strip other punctiuation (e.g. comma, period, colon, etc.)
+ *  This function will not attempt to remove "non-word characters" (e.g. ø) as defined by the JS regex parser
+ * @param name
+ */
+export function sanitizeName(name: string) {
+	name.replace(/\w/g, '').replace(/-/g, '_')
+}

--- a/src/showstyle0/migrations/triggered-actions-defaults.ts
+++ b/src/showstyle0/migrations/triggered-actions-defaults.ts
@@ -1,14 +1,15 @@
 import { IBlueprintTriggeredActions } from '@sofie-automation/blueprints-integration'
 import { literal } from '../../common/util'
+import { AdLibTags } from '../definitions'
 import { SourceLayer } from '../layers'
 import { createAdLibHotkey } from './util'
 
 export const TriggeredActionsDefaults = literal<IBlueprintTriggeredActions[]>([
 	...['F1', 'F2', 'F3', 'F4', 'F5', 'F6'].map((key, i) =>
-		createAdLibHotkey(key, [SourceLayer.Camera], true, i, undefined)
+		createAdLibHotkey(key, [SourceLayer.Camera], true, i, [AdLibTags.DirectCut])
 	),
 	...['F7', 'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5'].map((key, i) =>
-		createAdLibHotkey(key, [SourceLayer.Remote], true, i, undefined)
+		createAdLibHotkey(key, [SourceLayer.Remote], true, i, [AdLibTags.DirectCut])
 	),
 	...['F8'].map((key, i) => createAdLibHotkey(key, [SourceLayer.DVE], true, i, undefined)),
 	...['KeyQ', 'KeyW', 'KeyE', 'KeyR', 'KeyT', 'KeyY'].map((key, i) =>

--- a/src/showstyle0/rundown/globalAdlibs.ts
+++ b/src/showstyle0/rundown/globalAdlibs.ts
@@ -2,6 +2,7 @@ import { IBlueprintAdLibPiece, IShowStyleUserContext, PieceLifespan } from '@sof
 import { assertUnreachable, literal } from '../../common/util'
 import { AudioSourceType, SourceType, StudioConfig, VisionMixerType } from '../../studio0/helpers/config'
 import { SisyfosLayers } from '../../studio0/layers'
+import { adLibTagCamera, adLibTagLive, AdLibTags } from '../definitions'
 import { getAudioObjectOnLayer, getAudioPrimaryObject } from '../helpers/audio'
 import { createVisionMixerObjects } from '../helpers/visionMixer'
 import { getOutputLayerForSourceLayer, SourceLayer } from '../layers'
@@ -9,7 +10,7 @@ import { getOutputLayerForSourceLayer, SourceLayer } from '../layers'
 export function getGlobalAdlibs(context: IShowStyleUserContext): IBlueprintAdLibPiece[] {
 	const config = context.getStudioConfig() as StudioConfig
 
-	const makeCameraAdlib = (id: number, input: number): IBlueprintAdLibPiece => ({
+	const makeCameraAdlib = (id: number, input: number, queue: boolean): IBlueprintAdLibPiece => ({
 		_rank: 100 + id,
 		externalId: 'cam' + id,
 		name: `Camera ${id + 1}`,
@@ -22,8 +23,10 @@ export function getGlobalAdlibs(context: IShowStyleUserContext): IBlueprintAdLib
 				getAudioPrimaryObject(config, [{ type: AudioSourceType.Host, index: 0 }]),
 			],
 		},
+		tags: [AdLibTags.Camera, adLibTagCamera((id + 1).toString()), queue ? AdLibTags.Queue : AdLibTags.DirectCut],
+		toBeQueued: queue,
 	})
-	const makeRemoteAdlib = (id: number, input: number): IBlueprintAdLibPiece => ({
+	const makeRemoteAdlib = (id: number, input: number, queue: boolean): IBlueprintAdLibPiece => ({
 		_rank: 200 + id,
 		externalId: 'rem' + id,
 		name: `Remote ${id + 1}`,
@@ -36,6 +39,8 @@ export function getGlobalAdlibs(context: IShowStyleUserContext): IBlueprintAdLib
 				getAudioPrimaryObject(config, [{ type: AudioSourceType.Remote, index: id }]),
 			],
 		},
+		tags: [AdLibTags.Live, adLibTagLive((id + 1).toString()), queue ? AdLibTags.Queue : AdLibTags.DirectCut],
+		toBeQueued: queue,
 	})
 
 	const hostMicOverrides = [
@@ -70,23 +75,25 @@ export function getGlobalAdlibs(context: IShowStyleUserContext): IBlueprintAdLib
 	]
 
 	if (config.visionMixerType === VisionMixerType.Atem) {
+		const cameraSources = config.atemSources.filter((source) => source.type === SourceType.Camera)
+		const remoteSources = config.atemSources.filter((source) => source.type === SourceType.Remote)
+
 		return [
-			...config.atemSources
-				.filter((source) => source.type === SourceType.Camera)
-				.map((source, i) => makeCameraAdlib(i, source.input)),
-			...config.atemSources
-				.filter((source) => source.type === SourceType.Remote)
-				.map((source, i) => makeRemoteAdlib(i, source.input)),
+			...cameraSources.map((source, i) => makeCameraAdlib(i, source.input, false)),
+			...cameraSources.map((source, i) => makeCameraAdlib(i, source.input, true)),
+			...remoteSources.map((source, i) => makeRemoteAdlib(i, source.input, false)),
+			...remoteSources.map((source, i) => makeRemoteAdlib(i, source.input, true)),
 			...hostMicOverrides,
 		]
 	} else if (config.visionMixerType === VisionMixerType.VMix) {
+		const cameraSources = config.vmixSources.filter((source) => source.type === SourceType.Camera)
+		const remoteSources = config.vmixSources.filter((source) => source.type === SourceType.Remote)
+
 		return [
-			...config.vmixSources
-				.filter((source) => source.type === SourceType.Camera)
-				.map((source, i) => makeCameraAdlib(i, source.input)),
-			...config.vmixSources
-				.filter((source) => source.type === SourceType.Remote)
-				.map((source, i) => makeRemoteAdlib(i, source.input)),
+			...cameraSources.map((source, i) => makeCameraAdlib(i, source.input, false)),
+			...cameraSources.map((source, i) => makeCameraAdlib(i, source.input, true)),
+			...remoteSources.map((source, i) => makeRemoteAdlib(i, source.input, false)),
+			...remoteSources.map((source, i) => makeRemoteAdlib(i, source.input, true)),
 			...hostMicOverrides,
 		]
 	} else {


### PR DESCRIPTION
I've added tags to a couple of the global AdLibs so that dashboards can be created that, for example, show a panel of all camera AdLibs.

I've also added a set of "queue" AdLibs for the camera and remote sources, and updated the adlib trigger migrations to filter for adlibs tagged as "direct_cut" only, so that these new "queue" AdLibs don't get assigned to the shortcuts. The trigger migrations will ask if you would like to use the default value where your config differs from the default. Right now it asks for every value.

A lot of this has been motivated by setting up some demos of dashboard panels, hopefully some of this is useful but it's not an issue to leave this PR unmerged.

This is the demo panel, perhaps some example shelf layouts / dashboards could be included with the blueprints at some later date.
![image](https://user-images.githubusercontent.com/10697525/151207638-81141094-6e34-40cd-8fde-a2ddee075fbe.png)
