### PR TITLE
Fix off by one error in rundown label

### DIFF
--- a/packages/blueprints/src/showstyle0/helpers/dve.ts
+++ b/packages/blueprints/src/showstyle0/helpers/dve.ts
@@ -112,7 +112,7 @@ export function dveLayoutToContent(
 			: undefined
 
 		return literal<SplitsContentBoxContent & SplitsContentBoxProperties>({
-			studioLabel: 'fileName' in info ? info.fileName : `${info.type} ${info.id + 1}`,
+			studioLabel: 'fileName' in info ? info.fileName : `${info.type} ${info.id}`,
 			switcherInput:
 				'fileName' in info ? getClipPlayerInput(config)?.input || 0 : getSourceInfoFromRaw(config, info).input,
 			type:

--- a/packages/blueprints/src/showstyle0/helpers/sources.ts
+++ b/packages/blueprints/src/showstyle0/helpers/sources.ts
@@ -2,6 +2,7 @@ import { SourceType, StudioConfig, VisionMixerType } from '../../studio0/helpers
 
 export interface RawSourceInfo {
 	type: SourceType
+	/** 1-based number */
 	id: number
 }
 


### PR DESCRIPTION
The label in a DVE element in the rundown is incorrect, e.g. "Camera 2 and Remote 2" when it should be "Camera 1 and Remote 1"