### PR TITLE
feat: configure casparcg device

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
     "engines": {
         "node": ">=22.0.0"
     },
-    "packageManager": "yarn@4.9.1"
+    "packageManager": "yarn@4.10.3"
 }

--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -32,7 +32,7 @@
 		"typescript": "~5.8.3"
 	},
 	"dependencies": {
-		"@sofie-automation/blueprints-integration": "1.53.0-nightly-release53-20250423-081454-dc957dd.0",
+		"@sofie-automation/blueprints-integration": "1.53.0-nightly-release53-20250924-143640-007a9da.0",
 		"object-path": "^0.11.8",
 		"type-fest": "^4.40.1",
 		"underscore": "^1.13.7"

--- a/packages/blueprints/src/$schemas/generated/main-studio-config.ts
+++ b/packages/blueprints/src/$schemas/generated/main-studio-config.ts
@@ -8,6 +8,7 @@
 export interface StudioConfig {
 	visionMixer: VisionMixerConfig
 	audioMixer: AudioMixerConfig
+	casparcg: CasparCGConfig
 	atemSources: {
 		[k: string]: InputConfig
 	}
@@ -55,6 +56,19 @@ export interface AudioMixerConfig {
 	host: string
 	/**
 	 * Port of Sisyfos
+	 */
+	port: number
+}
+/**
+ * CasparCG device configuration
+ */
+export interface CasparCGConfig {
+	/**
+	 * Host IP of CasparCG
+	 */
+	host: string
+	/**
+	 * Port of CasparCG
 	 */
 	port: number
 }

--- a/packages/blueprints/src/$schemas/main-studio-config.json
+++ b/packages/blueprints/src/$schemas/main-studio-config.json
@@ -78,6 +78,31 @@
 			"required": ["deviceId", "host", "port"],
 			"additionalProperties": false
 		},
+		"casparcg": {
+			"type": "object",
+			"title": "CasparCGConfig",
+			"description": "CasparCG device configuration",
+			"ui:category": "CasparCG Device",
+			"ui:title": "CasparCG Device Configuration",
+			"properties": {
+				"host": {
+					"type": "string",
+					"description": "Host IP of CasparCG",
+					"ui:title": "Host Ip",
+					"ui:description": "Host IP of CasparCG",
+					"default": "127.0.0.1"
+				},
+				"port": {
+					"type": "integer",
+					"description": "Port of CasparCG",
+					"ui:title": "Port",
+					"ui:description": "Port of CasparCG (default is 5250)",
+					"default": 5250
+				}
+			},
+			"required": ["host", "port"],
+			"additionalProperties": false
+		},
 		"atemSources": {
 			"type": "object",
 			"ui:title": "Atem Sources",
@@ -213,7 +238,8 @@
 		"atemOutputs",
 		"atemSources",
 		"visionMixer",
-		"audioMixer"
+		"audioMixer",
+		"casparcg"
 	],
 	"$defs": {
 		"SourceType": {

--- a/packages/blueprints/src/base/studio/applyConfig/index.ts
+++ b/packages/blueprints/src/base/studio/applyConfig/index.ts
@@ -1,7 +1,6 @@
 import {
 	Accessor,
 	BlueprintConfigCoreConfig,
-	BlueprintMosDeviceConfig,
 	BlueprintParentDeviceSettings,
 	BlueprintResultApplyStudioConfig,
 	ICommonContext,
@@ -56,46 +55,61 @@ export function generateParentDevices(): Record<string, BlueprintParentDeviceSet
 	return parentDevices
 }
 
-function generatePlayoutDevices(config: BlueprintConfig): Record<string, TSR.DeviceOptionsAny> {
+function generatePlayoutDevices(config: BlueprintConfig): BlueprintResultApplyStudioConfig['playoutDevices'] {
 	const playoutDevices: BlueprintResultApplyStudioConfig['playoutDevices'] = {
-		['abstract']: literal<TSR.DeviceOptionsAbstract>({
-			type: TSR.DeviceType.ABSTRACT,
-		}),
-		['graphics']: literal<TSR.DeviceOptionsHTTPSend>({
-			type: TSR.DeviceType.HTTPSEND,
-			options: {},
-		}),
-		['casparcg0']: literal<TSR.DeviceOptionsCasparCG>({
-			type: TSR.DeviceType.CASPARCG,
-			options: {
-				host: config.studio.casparcg.host,
-				port: config.studio.casparcg.port || 5250,
-			},
-		}),
+		abstract: {
+			parentDeviceName: 'playoutgateway',
+			options: literal<TSR.DeviceOptionsAbstract>({
+				type: TSR.DeviceType.ABSTRACT,
+			}),
+		},
+		graphics: {
+			parentDeviceName: 'playoutgateway',
+			options: literal<TSR.DeviceOptionsHTTPSend>({
+				type: TSR.DeviceType.HTTPSEND,
+				options: {},
+			}),
+		},
+		casparcg0: {
+			parentDeviceName: 'playoutgateway',
+			options: literal<TSR.DeviceOptionsCasparCG>({
+				type: TSR.DeviceType.CASPARCG,
+				options: {
+					host: config.studio.casparcg.host,
+					port: config.studio.casparcg.port || 5250,
+				},
+			}),
+		},
 	}
 
 	if (config.studio.visionMixer.type === VisionMixerDevice.Atem) {
-		playoutDevices[config.studio.visionMixer.deviceId] = literal<TSR.DeviceOptionsAtem>({
-			type: TSR.DeviceType.ATEM,
-			options: {
-				host: config.studio.visionMixer.host,
-				port: config.studio.visionMixer.port,
-			},
-		})
+		playoutDevices[config.studio.visionMixer.deviceId] = {
+			parentDeviceName: 'playoutgateway',
+			options: literal<TSR.DeviceOptionsAtem>({
+				type: TSR.DeviceType.ATEM,
+				options: {
+					host: config.studio.visionMixer.host,
+					port: config.studio.visionMixer.port,
+				},
+			}),
+		}
 	}
 
-	playoutDevices[config.studio.audioMixer.deviceId] = literal<TSR.DeviceOptionsSisyfos>({
-		type: TSR.DeviceType.SISYFOS,
-		options: {
-			host: config.studio.audioMixer.host,
-			port: config.studio.audioMixer.port || 1176,
-		},
-	})
+	playoutDevices[config.studio.audioMixer.deviceId] = {
+		parentDeviceName: 'playoutgateway',
+		options: literal<TSR.DeviceOptionsSisyfos>({
+			type: TSR.DeviceType.SISYFOS,
+			options: {
+				host: config.studio.audioMixer.host,
+				port: config.studio.audioMixer.port || 1176,
+			},
+		}),
+	}
 	return playoutDevices
 }
 
-function generateIngestDevices(): Record<string, BlueprintMosDeviceConfig> {
-	const ingestDevices: Record<string, BlueprintMosDeviceConfig> = {}
+function generateIngestDevices(): BlueprintResultApplyStudioConfig['ingestDevices'] {
+	const ingestDevices: BlueprintResultApplyStudioConfig['ingestDevices'] = {}
 
 	return ingestDevices
 }

--- a/packages/blueprints/src/base/studio/applyConfig/index.ts
+++ b/packages/blueprints/src/base/studio/applyConfig/index.ts
@@ -47,6 +47,13 @@ function generatePlayoutDevices(config: BlueprintConfig): Record<string, TSR.Dev
 			type: TSR.DeviceType.HTTPSEND,
 			options: {},
 		}),
+		['casparcg0']: literal<TSR.DeviceOptionsCasparCG>({
+			type: TSR.DeviceType.CASPARCG,
+			options: {
+				host: config.studio.casparcg.host,
+				port: config.studio.casparcg.port || 5250,
+			},
+		}),
 	}
 
 	if (config.studio.visionMixer.type === VisionMixerDevice.Atem) {

--- a/packages/blueprints/src/base/studio/applyConfig/index.ts
+++ b/packages/blueprints/src/base/studio/applyConfig/index.ts
@@ -1,4 +1,5 @@
 import {
+	Accessor,
 	BlueprintConfigCoreConfig,
 	BlueprintMosDeviceConfig,
 	BlueprintParentDeviceSettings,
@@ -10,6 +11,8 @@ import { BlueprintConfig, StudioConfig, VisionMixerDevice } from '../helpers/con
 import { getMappingsDefaults } from './mappings/index.js'
 import { preprocessConfig } from '../preprocessConfig.js'
 import { literal } from '../../../common/util.js'
+// eslint-disable-next-line n/no-missing-import
+import { StudioPackageContainer } from '@sofie-automation/shared-lib/dist/core/model/PackageContainer.js'
 
 export function applyConfig(
 	context: ICommonContext,
@@ -24,6 +27,21 @@ export function applyConfig(
 		parentDevices: generateParentDevices(),
 		inputDevices: {},
 		ingestDevices: generateIngestDevices(),
+
+		packageContainers: generatePackageContainers(),
+
+		studioSettings: {
+			frameRate: 25,
+			mediaPreviewsUrl: '',
+			forceMultiGatewayMode: true,
+			supportedMediaFormats: '1280x720p5000',
+			minimumTakeSpan: 1000,
+
+			allowHold: false,
+			allowPieceDirectPlay: false,
+			enableBuckets: false,
+			enableEvaluationForm: true,
+		},
 	}
 }
 
@@ -80,4 +98,39 @@ function generateIngestDevices(): Record<string, BlueprintMosDeviceConfig> {
 	const ingestDevices: Record<string, BlueprintMosDeviceConfig> = {}
 
 	return ingestDevices
+}
+
+function generatePackageContainers(): Record<string, StudioPackageContainer> {
+	return {
+		httpProxy0: {
+			deviceIds: [],
+			container: {
+				label: 'Proxy for thumbnails & preview',
+				accessors: {
+					http0: {
+						type: Accessor.AccessType.HTTP_PROXY,
+						label: 'HTTP',
+						allowRead: true,
+						allowWrite: true,
+						baseUrl: 'http://localhost:8080/package', // TODO - config driven?
+					},
+				},
+			},
+		},
+		casparcg0: {
+			deviceIds: ['casparcg0'],
+			container: {
+				label: 'CasparCG Media folder',
+				accessors: {
+					casparcg0: {
+						type: Accessor.AccessType.LOCAL_FOLDER,
+						label: 'Local',
+						allowRead: true,
+						allowWrite: false,
+						folderPath: 'c:/casparcg/media', // TODO - config driven?
+					},
+				},
+			},
+		},
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,14 +3895,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/blueprints-integration@npm:1.53.0-nightly-release53-20250423-081454-dc957dd.0":
-  version: 1.53.0-nightly-release53-20250423-081454-dc957dd.0
-  resolution: "@sofie-automation/blueprints-integration@npm:1.53.0-nightly-release53-20250423-081454-dc957dd.0"
+"@sofie-automation/blueprints-integration@npm:1.53.0-nightly-release53-20250924-143640-007a9da.0":
+  version: 1.53.0-nightly-release53-20250924-143640-007a9da.0
+  resolution: "@sofie-automation/blueprints-integration@npm:1.53.0-nightly-release53-20250924-143640-007a9da.0"
   dependencies:
-    "@sofie-automation/shared-lib": "npm:1.53.0-nightly-release53-20250423-081454-dc957dd.0"
+    "@sofie-automation/shared-lib": "npm:1.53.0-nightly-release53-20250924-143640-007a9da.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.33.0"
-  checksum: 10c0/4a1f3b214f2532a2fb155073d0d05e4b14f6bcd4ca1b1ad1524f3581174c56f3c750074002d872c6364c2d0decb854497b7f653577203cc31d1a1b0e4608f45c
+  checksum: 10c0/7c46c47da0e654c5765813eb36d088f6833601ebc71126879267fd5e48910db24a0a41ab82b941244f200c92fc3d0b72f72c8696c0e8f450ffeb6124cc643f64
   languageName: node
   linkType: hard
 
@@ -3943,15 +3943,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sofie-automation/shared-lib@npm:1.53.0-nightly-release53-20250423-081454-dc957dd.0":
-  version: 1.53.0-nightly-release53-20250423-081454-dc957dd.0
-  resolution: "@sofie-automation/shared-lib@npm:1.53.0-nightly-release53-20250423-081454-dc957dd.0"
+"@sofie-automation/shared-lib@npm:1.53.0-nightly-release53-20250924-143640-007a9da.0":
+  version: 1.53.0-nightly-release53-20250924-143640-007a9da.0
+  resolution: "@sofie-automation/shared-lib@npm:1.53.0-nightly-release53-20250924-143640-007a9da.0"
   dependencies:
     "@mos-connection/model": "npm:^4.2.2"
-    timeline-state-resolver-types: "npm:9.3.0-release52.2"
+    timeline-state-resolver-types: "npm:9.4.0-nightly-release53-20250730-145840-ce6dce9c1.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.33.0"
-  checksum: 10c0/4a3db962ef3e76f638b10facf39f2c8d9a3d5ebcfca879387fe31660e118256e4c436be50983fcac653187f4f2b54f9642f2577b6b8c3619b7bc7e42e2db59e9
+  checksum: 10c0/7e03bbeb14b235793568c6775222d5aba43734d7ec1e4a79c58924557c40c99df29c8cae736a4e8f359be07819ae4a03b8aa94ca58a185136df88fc768c3954b
   languageName: node
   linkType: hard
 
@@ -5796,7 +5796,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "blueprints@workspace:packages/blueprints"
   dependencies:
-    "@sofie-automation/blueprints-integration": "npm:1.53.0-nightly-release53-20250423-081454-dc957dd.0"
+    "@sofie-automation/blueprints-integration": "npm:1.53.0-nightly-release53-20250924-143640-007a9da.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.15.3"
     "@types/object-path": "npm:^0.11.4"
@@ -17738,12 +17738,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:9.3.0-release52.2":
-  version: 9.3.0-release52.2
-  resolution: "timeline-state-resolver-types@npm:9.3.0-release52.2"
+"timeline-state-resolver-types@npm:9.4.0-nightly-release53-20250730-145840-ce6dce9c1.0":
+  version: 9.4.0-nightly-release53-20250730-145840-ce6dce9c1.0
+  resolution: "timeline-state-resolver-types@npm:9.4.0-nightly-release53-20250730-145840-ce6dce9c1.0"
   dependencies:
     tslib: "npm:^2.6.3"
-  checksum: 10c0/c7f43960b0a98e6a1eb40b3ac6f42053f21528ae63f8151bebbd608056cb6fbc4687fa6141a627c7c14fd0581b49c0b6c10a4d19d1da346b6830093a6f5159b2
+  checksum: 10c0/61ea4a31ee469b4070124045ff1dc4a92a287ce1f6ec2f3c15bfa4e3024c5c70d281933fd4e84be5fe0b832e75136a2c97409b02390740cf60de44506d8dc924
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
SOFIE-42 & SOFIE-43

Fixes the missing casparcg device, provides most of the package-manager configuration and update blueprints-integration to latest r53